### PR TITLE
fix: created_time doesnt get updated correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "dsiem"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "dsiem-ui"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "chrono",
  "gloo-console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "1.2.4"
+version = "1.2.5"
 authors = ["Dsiem Authors"]
 description = "OSSIM-style event correlation engine for ELK stack"
 documentation = "https://github.com/defenxor/dsiem/blob/master/docs/README.md"


### PR DESCRIPTION
Error caused by recent change from rwlock to atomic for certain backlog fields.
